### PR TITLE
allows parseSides to accept a number as an argument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d3plus-common",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/parseSides.js
+++ b/src/parseSides.js
@@ -1,10 +1,12 @@
 /**
  @function parseSides
  @desc Converts a string of directional CSS shorthand values into an object with the values expanded.
- @param {String} sides The CSS shorthand string to expand.
+ @param {String|Number} sides The CSS shorthand string to expand.
  */
 export default function(sides) {
-  let values = sides.split(/\s+/);
+  let values;
+  if (typeof sides === "number") values = [sides];
+  else values = sides.split(/\s+/);
 
   if (values.length === 1) values = [values[0], values[0], values[0], values[0]];
   else if (values.length === 2) values = values.concat(values);

--- a/test/parseSides.js
+++ b/test/parseSides.js
@@ -10,6 +10,7 @@ test("parseSides", assert => {
   assert.deepEqual(parseSides("10 20 30 40"), {top: 10, right: 20, bottom: 30, left: 40}, "Four value");
   assert.deepEqual(parseSides("10 20 30 40 50"), {top: 10, right: 20, bottom: 30, left: 40}, "More than four values");
   assert.deepEqual(parseSides("10px 20px 30px"), {top: 10, right: 20, bottom: 30, left: 20}, "px values");
+  assert.deepEqual(parseSides(40), {top: 40, right: 40, bottom: 40, left: 40}, "number value");
 
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### Description
Modify the parseSides function to accept a number as an argument.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [x] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

