### PR TITLE
modifies configPrep function to improve mobile support

### DIFF
--- a/src/configPrep.js
+++ b/src/configPrep.js
@@ -14,16 +14,15 @@ export default function configPrep(config = this._shapeConfig, type = "shape", n
       i = d.i;
       d = d.data || d.feature;
     }
-    return func(d, i, s);
+    return func.bind(this)(d, i, s);
   };
 
   const parseEvents = (newObj, on) => {
 
     for (const event in on) {
 
-      if ({}.hasOwnProperty.call(on, event) && !event.includes(".") || event.includes(`.${type}`) || event.includes(".all")) {
-        const eventName = event.replace(/click(\.[a-z]*)/g, "click$1 touchstart$1");
-        newObj.on[eventName] = wrapFunction(on[event]);
+      if ({}.hasOwnProperty.call(on, event) && !event.includes(".") || event.includes(`.${type}`)) {
+        newObj.on[event] = wrapFunction(on[event]);
       }
 
     }


### PR DESCRIPTION
This PR along with [this PR in d3plus-viz](https://github.com/d3plus/d3plus-viz/pull/79) closes [this issue in d3plus-viz](https://github.com/d3plus/d3plus-viz/issues/78)
<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
- binds `this` to custom event listener functions
- removes logic to handle `.all` events
- removes logic that attaches click event listeners as `click` and `touchstart` event listeners

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

