### PR TITLE
adds a catch for "on" config events to allow nulls

### DIFF
--- a/src/configPrep.js
+++ b/src/configPrep.js
@@ -10,6 +10,7 @@ export default function configPrep(config = this._shapeConfig, type = "shape", n
   const newConfig = {duration: this._duration, on: {}};
 
   const wrapFunction = func => (d, i, s, e) => {
+    if (!func) return func;
     let parent;
     while (d.__d3plus__) {
       if (parent) d.__d3plusParent__ = parent;


### PR DESCRIPTION
Without this, while setting something like `.on({"click.shape": null})` would disable the default shape click event for a viz, it would also result in a console error message as a result of trying to apply `.bind` to a non-function.