### PR TITLE
allows unique function to compare Date objects

### DIFF
--- a/src/unique.js
+++ b/src/unique.js
@@ -9,6 +9,14 @@ unique(["apple", "banana", "apple"]);
 ["apple", "banana"]
 */
 export default function(arr, accessor = d => d) {
-  const values = arr.map(accessor);
-  return arr.filter((d, i) => values.indexOf(accessor(d)) === i);
+
+  const values = arr
+    .map(accessor)
+    .map(d => d instanceof Date ? +d : d);
+
+  return arr.filter((obj, i) => {
+    const d = accessor(obj);
+    return values.indexOf(d instanceof Date ? +d : d) === i;
+  });
+
 }

--- a/test/unique.js
+++ b/test/unique.js
@@ -1,0 +1,15 @@
+import {test} from "zora";
+import {default as unique} from "../src/unique.js";
+
+test("unique", assert => {
+
+  assert.equal(unique(["a", "a", "b"]).join(","), "a,b", "Strings");
+  assert.equal(unique([1, 2, 1]).join(","), "1,2", "Numbers");
+
+  const firstDate = new Date("1987/06/12");
+  const secondDate = new Date("1987/06/12");
+  assert.equal(unique([firstDate, secondDate]).join(","), firstDate.toString(), "Dates");
+
+});
+
+export default test;


### PR DESCRIPTION
This issue arose from when users pass their own Date objects inside of the `data` objects of a viz. Take the following example of 2 dates:

```js
const firstDate = new Date("1987/06/12");
const secondDate = new Date("1987/06/12");
```

Currently, the `unique` function sees these two variables as different dates, because Dates are _Objects_ in JavaScript and cannot be compared. This PR converts Date Objects to _Numbers_ when trying to compare them for uniqueness.