### PR TITLE
adds arabic common translations

### DIFF
--- a/src/locales/ar-SA.js
+++ b/src/locales/ar-SA.js
@@ -1,0 +1,19 @@
+export default {
+    "and": "و",
+    "Back": "للخلف",
+    "Click to Expand": "انقر للتوسيع",
+    "Click to Hide": "اضغط للإخفاء",
+    "Click to Highlight": "اضغط للتحديد",
+    "Click to Show": "انقر للعرض",
+    "Click to Show All": "انقر لعرض الكل",
+    "Download": "تحميل",
+    "Loading Visualization": "جاري تحميل التصوير البياني",
+    "No Data Available": "لا تتوفر بيانات",
+    "Powered by D3plus": "مدعوم بواسطة D3plus",
+    "Share": "مشاركة",
+    "Shift+Click to Hide": "Shift+انقر للإخفاء",
+    "Shift+Click to Highlight": "Shift + للتحديد اضغط",
+    "Total": "المجموع",
+    "Values": "القيم"
+  };
+  

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -1,7 +1,9 @@
 import esES from "./es-ES.js";
 import ptBR from "./pt-BR.js";
+import arSA from "./ar-SA.js";
 
 export default {
   "es-ES": esES,
-  "pt-BR": ptBR
+  "pt-BR": ptBR,
+  "ar-SA": arSA,
 };


### PR DESCRIPTION
Adds arabic translations for d3plus internal texts.

Notes:
- Not 100% if we need to add the locale somewhere else.
- I couldn't set up the dev environment and run the tests (there is an error running `npm i`.